### PR TITLE
Make thread sleep after setting pin to low

### DIFF
--- a/source/app.d
+++ b/source/app.d
@@ -29,6 +29,7 @@ void main()
             pin,
             gpio.LOW
         );
+        Thread.sleep(dur!("seconds")(1));
     }
 
     writeln("Done.");


### PR DESCRIPTION
The loop was setting the pin to high, sleeping for 1 second, setting the pin to low, and then going to the next iteration which sets the pin to high again.  It needs to sleep after setting the pin to low to make it blink.